### PR TITLE
Allow PHP versions higher than 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.3 | 8.0",
+        "php": "^7.3 | ^8.0",
         "symfony/console": "^4.4 | ^5.1",
         "laminas/laminas-mvc": "~3.0",
         "laminas/laminas-servicemanager": "~3.0",


### PR DESCRIPTION
Hi!

I am encountering an error when I want to install this module with PHP 8.0.16.

I changed the PHP version requirement of this module to resolve the error.

Thanks for your job.

